### PR TITLE
Create `$BROCKMAN_DIR` if it doesn't exist

### DIFF
--- a/brockman.sh
+++ b/brockman.sh
@@ -65,6 +65,18 @@ resolve() {
 
 ALLOWED_VIEW_TYPES="^(alert|error)$"
 
+setup() {
+    if [ ! -d "$BROCKMAN_DIR" ]
+    then
+        mkdir $BROCKMAN_DIR
+    fi
+
+    touch $BROCKMAN_ALERT_LOG
+    touch $BROCKMAN_ERROR_LOG
+}
+
+setup
+
 case $1 in
 --report)
     if [ $# -lt 2 ]


### PR DESCRIPTION
This prevents the user from having to do any initialization
or setup the first time they use `brockman`.