### PR TITLE
Modify brockman cli to be more idiomatic

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,13 +30,13 @@ failure, *brockman* will log both an `alert` that the task failed, and an
 `error` log of the failure. It logs these errors to
 `~/.brockman/{alert,error}.log` respectively.
 
-Ex: `brockman.sh --report "clamscan -r ~/"`
+Ex: `brockman.sh report "clamscan -r ~/"`
 
 ### Failure
 
 `failure` succeeds if *brockman* has unresolved errors, and fails if not.
 
-Ex: `brockman.sh --failure`
+Ex: `brockman.sh failure`
 
 ### View
 
@@ -44,7 +44,7 @@ Ex: `brockman.sh --failure`
 which is a brief description of the command which failed, or the `error` log,
 which is the entire output of `stderr` for the failed command.
 
-Ex: `brockman.sh --view [alert|error]`
+Ex: `brockman.sh view [alert|error]`
 
 ### Resolve
 
@@ -52,7 +52,7 @@ Ex: `brockman.sh --view [alert|error]`
 call it after you've copied whatever info you need from *brockman* logs to a
 more permanent location.
 
-Ex: `brockman.sh --resolve`
+Ex: `brockman.sh resolve`
 
 ## Use cases
 
@@ -60,12 +60,12 @@ Ex: `brockman.sh --resolve`
 a single task well.
 
 I use it for monitoring nightly updates, anti-virus scans, and local ansible
-playbook runs. I run these cron jobs with `brockman.sh --report "$CMD"` and then
-add `brockman.sh --failure` to alert if one of these tasks failed when I open a
-new shell. If there has been a failure, I use `brockman.sh --view alert` and
-`brockman.sh --view error` to investigate further. Finally, after resolving the
-issue, I run `brockman.sh --resolve` so *brockman* won't alert me to this error
-again.
+playbook runs. I run these cron jobs with `brockman.sh report "$CMD"` and then
+add `brockman.sh failure` to my `~/.bashrc` to alert if one of
+these tasks failed when I open a new shell. If there has been a failure,
+I use `brockman.sh view alert` and `brockman.sh view error` to investigate further.
+Finally, after resolving the issue, I run `brockman.sh resolve`
+so *brockman* won't alert me to this error again.
 
 ## Contributing
 

--- a/brockman.sh
+++ b/brockman.sh
@@ -78,10 +78,10 @@ setup() {
 setup
 
 case $1 in
---report)
+report)
     if [ $# -lt 2 ]
     then
-        echo "Must pass a command to \`--report\`." >&2
+        echo "Must pass a command to \`report\`." >&2
         exit 2
     fi
 
@@ -91,19 +91,19 @@ case $1 in
     shift
     report "$@"
     ;;
---failure)
+failure)
     failure
     ;;
---view)
+view)
     if [ $# -ne 2 ] && ! echo "$2" | grep -q "$ALLOWED_VIEW_TYPES"
     then
-        echo "Must pass a $ALLOWED_VIEW_TYPES to \`--view\`." >&2
+        echo "Must pass a $ALLOWED_VIEW_TYPES to \`view\`." >&2
         exit 2
     fi
 
     view "$2"
     ;;
---resolve)
+resolve)
     resolve
     ;;
 *)

--- a/test/test_brockman.sh
+++ b/test/test_brockman.sh
@@ -35,10 +35,10 @@ log_error() {
 
 test_option_processing() {
     invalid_commands=(
-        --report
-        --fake-argument
-        --view
-        --view\ INVALID_TYPE
+        report
+        fake-argument
+        view
+        view\ INVALID_TYPE
     )
 
     for invalid_command in ${invalid_commands[@]}
@@ -63,19 +63,19 @@ EOF
 
     chmod u+x $success_script
 
-    $PATH_TO_BROCKMAN --report "$success_script ARGUMENT"
+    $PATH_TO_BROCKMAN report "$success_script ARGUMENT"
 
-    if $PATH_TO_BROCKMAN --view alert | grep -q "$success_script"
+    if $PATH_TO_BROCKMAN view alert | grep -q "$success_script"
     then
-        log_error "--report should not log alert containing $success_script"
+        log_error "report should not log alert containing $success_script"
     fi
 
-    if $PATH_TO_BROCKMAN --view error | grep -q "ARGUMENT"
+    if $PATH_TO_BROCKMAN view error | grep -q "ARGUMENT"
     then
-        log_error "--report should not log error containing ARGUMENT"
+        log_error "report should not log error containing ARGUMENT"
     fi
 
-    $PATH_TO_BROCKMAN --resolve
+    $PATH_TO_BROCKMAN resolve
 }
 
 test_report_failure() {
@@ -88,41 +88,41 @@ EOF
 
     chmod u+x $error_script
 
-    $PATH_TO_BROCKMAN --report "$error_script ARGUMENT"
+    $PATH_TO_BROCKMAN report "$error_script ARGUMENT"
 
-    if ! $PATH_TO_BROCKMAN --view alert | grep -q "$error_script"
+    if ! $PATH_TO_BROCKMAN view alert | grep -q "$error_script"
     then
-        log_error "--report should log alert containing $error_script"
+        log_error "report should log alert containing $error_script"
     fi
 
-    if ! $PATH_TO_BROCKMAN --view error | grep -q "ARGUMENT"
+    if ! $PATH_TO_BROCKMAN view error | grep -q "ARGUMENT"
     then
-        log_error "--report should log error containing ARGUMENT"
+        log_error "report should log error containing ARGUMENT"
     fi
 
-    $PATH_TO_BROCKMAN --resolve
+    $PATH_TO_BROCKMAN resolve
 }
 
 test_failure() {
-    $PATH_TO_BROCKMAN --failure
+    $PATH_TO_BROCKMAN failure
     exit_code=$?
 
     if [ "$exit_code" -ne 1 ]
     then
-        log_error "--failure should fail when there is no error."
+        log_error "failure should fail when there is no error."
     fi
 
     echo 'error' > $BROCKMAN_ALERT_LOG
 
-    $PATH_TO_BROCKMAN --failure
+    $PATH_TO_BROCKMAN failure
     exit_code=$?
 
     if [ "$exit_code" -ne 0 ]
     then
-        log_error "--failure should succeed when errors exist."
+        log_error "failure should succeed when errors exist."
     fi
 
-    $PATH_TO_BROCKMAN --resolve
+    $PATH_TO_BROCKMAN resolve
 }
 
 test_view() {
@@ -132,26 +132,26 @@ test_view() {
     echo "$alert_message" > $BROCKMAN_ALERT_LOG
     echo "$error_message" > $BROCKMAN_ERROR_LOG
 
-    alert_view=$($PATH_TO_BROCKMAN --view alert)
-    error_view=$($PATH_TO_BROCKMAN --view error)
+    alert_view=$($PATH_TO_BROCKMAN view alert)
+    error_view=$($PATH_TO_BROCKMAN view error)
 
     if [ "$alert_view" != "$alert_message" ]
     then
-        log_error "--view alert should display $alert_message"
+        log_error "view alert should display $alert_message"
     fi
 
     if [ "$error_view" != "$error_message" ]
     then
-        log_error "--view error should display $error_message"
+        log_error "view error should display $error_message"
     fi
 
-    $PATH_TO_BROCKMAN --resolve
+    $PATH_TO_BROCKMAN resolve
 }
 
 test_resolve() {
     echo 'error' | tee $BROCKMAN_ALERT_LOG $BROCKMAN_ERROR_LOG >/dev/null
 
-    $PATH_TO_BROCKMAN --resolve
+    $PATH_TO_BROCKMAN resolve
 
     log_files=(
         $BROCKMAN_ALERT_LOG
@@ -162,7 +162,7 @@ test_resolve() {
     do
         if [ -s "$log_file" ]
         then
-            log_error "--resolve should have cleared out: $log_file."
+            log_error "resolve should have cleared out: $log_file."
         fi
     done
 }


### PR DESCRIPTION
Fix #3 

Strip the `--` prefix from the four main brockman commands.
For example, `--resolve` => `resolve`. Prefixing main functionality
with `--` gave the impression that these values were optional,
which was confusing.