### PR TITLE
Update brockman source code documentation

### DIFF
--- a/brockman.sh
+++ b/brockman.sh
@@ -3,21 +3,34 @@
 # A lightweight utility for reporting on background unix processes.
 # See https://github.com/mattjmcnaughton/brockman for more info.
 
-BROCKMAN_DIR="${BROCKMAN_DIR:?~/.brockman}"
-BROCKMAN_ALERT_LOG="$BROCKMAN_DIR/alert.log"
-BROCKMAN_ERROR_LOG="$BROCKMAN_DIR/error.log"
+# `BROCKMAN_DIR` stores the alert/error log, in addition to potential additional configuration.
+# If there is already an existing environment variable when we run `brockman.sh`, that value will
+# be used. If not, it defaults to `~/.brockman`. Passing in the specialized `$BROCKMAN_DIR`
+# is necessary for testing.
+readonly BROCKMAN_DIR="${BROCKMAN_DIR:?~/.brockman}"
+readonly BROCKMAN_ALERT_LOG="$BROCKMAN_DIR/alert.log"
+readonly BROCKMAN_ERROR_LOG="$BROCKMAN_DIR/error.log"
 
-tmp_error_file=
+# Only certain options can be passed to the view command (representing the `{alert,error}.log`).
+readonly ALLOWED_VIEW_TYPES="^(alert|error)$"
 
-remove_tmp_err_file() {
-    if [ -n "$tmp_error_file" ] && [ -f "$tmp_error_file" ]
+# The report processes which its file to a temporary file while running. Then, if the report command
+# exits in failure, we copy the error file over to `$BROCKMAN_ERROR_LOG`. We want to use a different
+# temporary error file each time.
+REPORT_PROCESSES_ERROR_FILE=
+
+# Clean up the report processes error file. If we create `$REPORT_PROCESSES_ERROR_FILE`, set
+# a trap to clean it up on exit.
+brockman::remove_report_processes_error_file() {
+    if [ -n "$REPORT_PROCESSES_ERROR_FILE" ] && [ -f "$REPORT_PROCESSES_ERROR_FILE" ]
     then
-        rm $tmp_error_file
+        rm $REPORT_PROCESSES_ERROR_FILE
     fi
 }
 
-report() {
-    bash -c "$@ > $tmp_error_file 2>&1"
+# Run the processes passed as an argument and report errors appropriately.
+brockman::report() {
+    bash -c "$@ > $REPORT_PROCESSES_ERROR_FILE 2>&1"
     exit_code=$?
 
     if [ "$exit_code" -ne 0 ]
@@ -29,18 +42,20 @@ Command $@ failed with exit code $exit_code: See $BROCKMAN_ERROR_LOG for further
 details.
 EOF
 
-        cat $tmp_error_file >> $BROCKMAN_ERROR_LOG
+        cat $REPORT_PROCESSES_ERROR_FILE >> $BROCKMAN_ERROR_LOG
     fi
 }
 
-failure() {
+# Return success if brockman has unreported errors and fail if not.
+brockman::failure() {
     if [ ! -s "$BROCKMAN_ALERT_LOG" ]
     then
         exit 1
     fi
 }
 
-view() {
+# Output the alert/error logs. Takes `[alert|error]` as an argument.
+brockman::view() {
     if [ "$1" = "alert" ]
     then
         cat $BROCKMAN_ALERT_LOG
@@ -50,7 +65,8 @@ view() {
     fi
 }
 
-resolve() {
+# Clear the alert/error logs. `resolve` will delete all data.
+brockman::resolve() {
     log_files=(
         $BROCKMAN_ALERT_LOG
         $BROCKMAN_ERROR_LOG
@@ -63,9 +79,8 @@ resolve() {
     done
 }
 
-ALLOWED_VIEW_TYPES="^(alert|error)$"
-
-setup() {
+# If any of the log files/directories don't exist, create them.
+brockman::setup() {
     if [ ! -d "$BROCKMAN_DIR" ]
     then
         mkdir $BROCKMAN_DIR
@@ -75,7 +90,7 @@ setup() {
     touch $BROCKMAN_ERROR_LOG
 }
 
-setup
+brockman::setup
 
 case $1 in
 report)
@@ -85,14 +100,16 @@ report)
         exit 2
     fi
 
-    tmp_error_file=$(mktemp)
-    trap 'remove_tmp_err_file' EXIT
+    REPORT_PROCESSES_ERROR_FILE=$(mktemp)
+
+    # To prevent leaking of any tmp files.
+    trap 'brockman::remove_report_processes_error_file' EXIT
 
     shift
-    report "$@"
+    brockman::report "$@"
     ;;
 failure)
-    failure
+    brockman::failure
     ;;
 view)
     if [ $# -ne 2 ] && ! echo "$2" | grep -q "$ALLOWED_VIEW_TYPES"
@@ -101,10 +118,10 @@ view)
         exit 2
     fi
 
-    view "$2"
+    brockman::view "$2"
     ;;
 resolve)
-    resolve
+    brockman::resolve
     ;;
 *)
     echo "Invalid args." >&2
@@ -112,4 +129,5 @@ resolve)
     ;;
 esac
 
+# If here, then command executed successfully.
 exit 0


### PR DESCRIPTION
Fix #4 

Add documentation of the brockman public interface, and
comments for "gotchas". Also, prefix functions
with `brockman::` or `test_brockman::`.